### PR TITLE
Ics

### DIFF
--- a/lib/Micronomy.pm6
+++ b/lib/Micronomy.pm6
@@ -7,6 +7,8 @@ use URI::Encode;
 use Micronomy::Cache;
 use Micronomy::Common;
 use Micronomy::Demo;
+use Micronomy::Calendar;
+
 
 class Micronomy {
     my $server = "https://b3iaccess.deltekenterprise.com";
@@ -1134,5 +1136,25 @@ class Micronomy {
                    expires => DateTime.now(),
                   );
         redirect "/login?reason=Utloggad!", :see-other;
+    }
+
+    method calendar(:$date,:$token is copy,) {
+        if $date.Str.chars != 4 { #if date is not given provided "correctly" or if loading first page.
+            header "X-Frame-Options: DENY";
+            template 'calendar.html.tmpl', {
+                ics => "",
+                date => "",
+            }
+        } else { #if we have four characters not safe but working future fix.
+            trace "getting calendar ", $date;
+            my $datestring = $date.Str ~"-01-01";
+            my $querydate = Date.new($datestring);
+            my $data = calendargenerator($querydate);
+            header "X-Frame-Options: DENY";
+            template 'calendar.html.tmpl', {
+                ics => $data,
+                date => $querydate.year,
+            }
+        }
     }
 }

--- a/lib/Micronomy/Calendar.pm6
+++ b/lib/Micronomy/Calendar.pm6
@@ -17,12 +17,12 @@ sub initreddaygenerator($requestedyear) {
     }
     loop (my $i = 0; $i < $roof; $i++ ){
         my $tmp = $date +$i; 
-                #call for expected($date) as this will return work hours and inform of what kind of day it is.
-                given my $val = expected($tmp) {
-                        when 6 {@arrayofdates.push(@($tmp, 6));} #quarter day
-                        when 4 {@arrayofdates.push(@($tmp, 4));} #half day
-                        when 0 {@arrayofdates.push(@($tmp, 0));} #full day
-                }
+	next if ( $day.day-of-week > 5 );; 
+	given my $val = expected($tmp) {
+		when 6 {@arrayofdates.push(@($tmp, 6));} #quarter day
+		when 4 {@arrayofdates.push(@($tmp, 4));} #half day
+		when 0 {@arrayofdates.push(@($tmp, 0));} #full day
+	}
     }
     @arrayofdates, $date; #sending: [2021-01-01, 2021-01-05...], 2021-01-01
 }

--- a/lib/Micronomy/Calendar.pm6
+++ b/lib/Micronomy/Calendar.pm6
@@ -1,0 +1,86 @@
+unit module Micronomy::Calendar;
+
+use Micronomy::Demo;
+use Micronomy::Cache;
+use Micronomy::Common;
+
+sub initreddaygenerator($requestedyear) {
+    #iterates over a year and produces init red days. $requested should be YYYY-MM-DD and a Date class.
+    my $date = $requestedyear.truncated-to('year'); #YYYY-01-01 to start iteration on jan frst.
+    my @arrayofdates; 
+    my $roof = 0;
+    if $date.is-leap-year {
+        $roof = 366;
+    }
+    else {
+        $roof = 365;
+    }
+    loop (my $i = 0; $i < $roof; $i++ ){
+        my $tmp = $date +$i; 
+                #call for expected($date) as this will return work hours and inform of what kind of day it is.
+                given my $val = expected($tmp) {
+                        when 6 {@arrayofdates.push(@($tmp, 6));} #quarter day
+                        when 4 {@arrayofdates.push(@($tmp, 4));} #half day
+                        when 0 {@arrayofdates.push(@($tmp, 0));} #full day
+                }
+    }
+    @arrayofdates, $date; #sending: [2021-01-01, 2021-01-05...], 2021-01-01
+}
+
+#sub calendargenerator(@arrayofdates, $date){
+sub calendargenerator($querydate) is export {
+    my $list = initreddaygenerator($querydate);
+    #@list = [[(2021-01-01 0)(2021-01-05 6)]2021-01-01]
+    #@arrayofdates = [(2021-01-01 0) (2021-01-05 6)...]
+    #$date = 2021-01-01
+    my @arrayofdates = $list[0];
+    my $date = $list[1];
+    my $calendarstring = ""; 
+    my $counter = 0;
+    my $prodid = "Init-Micronomy-" ~ $date.year.Str ~ "\r\n"; #part of vcalendar
+    my $version = "2.0\r\n"; #part of vcalendar
+    $calendarstring = $calendarstring ~ "BEGIN:VCALENDAR\r\n";
+    $calendarstring = $calendarstring ~ "PRODID:" ~ $prodid;
+    $calendarstring = $calendarstring ~ "VERSION:" ~ $version; 
+    for @arrayofdates -> @pair {
+        $counter++;
+        #@pair  = (YYYY-MM-DD, H) where H is quarrter/half/full day of work. see initreddaygenerator.
+        my $dtstamp = sprintf "%04d%02d%02d%s", $date.year, $date.month, $date.day, "T150000\r\n";
+        my $startdate = @pair[0];
+        my $daytype = @pair[1];
+        my $dtstart = "";
+        my $dtend ="";
+        my $uid = "";
+        my $summary ="";
+        my $dayafter = $startdate + 1;
+        given $daytype {
+            when 6 {
+                $uid = "Init-Micronomy-" ~ $startdate.year().Str ~ "-" ~ $counter.Str ~ "\r\n";
+                $summary = "Quarter red day\r\n";
+                $dtstart = sprintf "%04d%02d%02d%s", $startdate.year, $startdate.month, $startdate.day, "T150000\r\n";
+                $dtend = sprintf "%04d%02d%02d%s", $dayafter.year, $dayafter.month, $dayafter.day, "T000000\r\n";
+            } 
+            when 4 {
+                $uid = "Init-Micronomy-" ~ $startdate.year().Str ~ "-" ~ $counter.Str ~ "\r\n";
+                $summary = "half red day\r\n";
+                $dtstart = sprintf "%04d%02d%02d%s", $startdate.year, $startdate.month, $startdate.day, "T130000\r\n";
+                $dtend = sprintf "%04d%02d%02d%s", $dayafter.year, $dayafter.month, $dayafter.day, "T000000\r\n";
+            } 
+            when 0 {
+                $uid = "Init-Micronomy-" ~ $startdate.year().Str ~ "-" ~ $counter.Str ~ "\r\n";
+                $summary = "Full red day\r\n";
+                $dtstart = sprintf "%04d%02d%02d%s", $startdate.year, $startdate.month, $startdate.day, "T000000\r\n";
+                $dtend = sprintf "%04d%02d%02d%s", $dayafter.year, $dayafter.month, $dayafter.day, "T000000\r\n";
+            } 
+        }
+        $calendarstring = $calendarstring ~ "BEGIN:VEVENT\r\n";
+        $calendarstring = $calendarstring ~ "UID:" ~ $uid;
+        $calendarstring = $calendarstring ~ "DTSTAMP:" ~ $dtstamp;
+        $calendarstring = $calendarstring ~ "DTSTART:" ~$dtstart; 
+        $calendarstring = $calendarstring ~ "DTEND:" ~ $dtend;
+        $calendarstring = $calendarstring ~ "SUMMARY:" ~ $summary; 
+        $calendarstring = $calendarstring ~ "END:VEVENT\r\n";
+    }
+    $calendarstring = $calendarstring ~ "END:VCALENDAR\r\n";
+    return $calendarstring;
+}

--- a/lib/Micronomy/Calendar.pm6
+++ b/lib/Micronomy/Calendar.pm6
@@ -83,4 +83,18 @@ sub calendargenerator($querydate) is export {
     }
     $calendarstring = $calendarstring ~ "END:VCALENDAR\r\n";
     return $calendarstring;
+
+    #sends a string that is an ics string shhort example of what it looks like here.
+    #BEGIN:VCALENDAR
+    #PRODID:Init-Micronomy-2023
+    #VERSION:2.0
+    #BEGIN:VEVENT 
+    #UID:Init-Micronomy-2023-121
+    #DTSTAMP:20230101T150000
+    #DTSTART:20231231T000000
+    #DTEND:20240101T000000
+    #SUMMARY:Full red day
+    #END:VEVENT
+    #END:VCALENDAR
+
 }

--- a/lib/Micronomy/Calendar.pm6
+++ b/lib/Micronomy/Calendar.pm6
@@ -56,19 +56,19 @@ sub calendargenerator($querydate) is export {
         given $daytype {
             when 6 {
                 $uid = "Init-Micronomy-" ~ $startdate.year().Str ~ "-" ~ $counter.Str ~ "\r\n";
-                $summary = "Quarter red day\r\n";
+                $summary = "kvarts röd dag\r\n";
                 $dtstart = sprintf "%04d%02d%02d%s", $startdate.year, $startdate.month, $startdate.day, "T150000\r\n";
                 $dtend = sprintf "%04d%02d%02d%s", $dayafter.year, $dayafter.month, $dayafter.day, "T000000\r\n";
             } 
             when 4 {
                 $uid = "Init-Micronomy-" ~ $startdate.year().Str ~ "-" ~ $counter.Str ~ "\r\n";
-                $summary = "half red day\r\n";
+                $summary = "halv röd dag\r\n";
                 $dtstart = sprintf "%04d%02d%02d%s", $startdate.year, $startdate.month, $startdate.day, "T130000\r\n";
                 $dtend = sprintf "%04d%02d%02d%s", $dayafter.year, $dayafter.month, $dayafter.day, "T000000\r\n";
             } 
             when 0 {
                 $uid = "Init-Micronomy-" ~ $startdate.year().Str ~ "-" ~ $counter.Str ~ "\r\n";
-                $summary = "Full red day\r\n";
+                $summary = "hel röd dag\r\n";
                 $dtstart = sprintf "%04d%02d%02d%s", $startdate.year, $startdate.month, $startdate.day, "T000000\r\n";
                 $dtend = sprintf "%04d%02d%02d%s", $dayafter.year, $dayafter.month, $dayafter.day, "T000000\r\n";
             } 

--- a/lib/Micronomy/Demo.pm6
+++ b/lib/Micronomy/Demo.pm6
@@ -229,7 +229,7 @@ sub sum-up-demo(Str $date, %cache, $filler = -1) {
     return %cache;
 }
 
-sub expected($day) {
+sub expected($day) is export {
     return 0 if $day.day-of-week > 5;
     given sprintf "%02d%02d", $day.month, $day.day {
         when "0101"                   { return 0; }  # Nyårsdagen

--- a/lib/Routes.pm6
+++ b/lib/Routes.pm6
@@ -89,6 +89,25 @@ sub routes() is export {
             }
         }
 
+        post -> 'calendar', :$sessionToken is cookie = '' , :$date {
+        if $sessionToken {
+            request-body -> (:$date){
+            Micronomy.calendar(date => $date);
+            }
+        } else {
+            redirect "/login", :see-other;
+        }
+        } 
+
+        get -> 'calendar', $sessionToken is cookie = '', {
+        if $sessionToken {
+            Micronomy.calendar(date => '');
+        } else {
+            redirect "/login", :see-other;
+        }
+        } 
+
+
         get -> 'styles', *@path {
             static "resources/styles", @path;
         }
@@ -98,26 +117,8 @@ sub routes() is export {
         get -> 'clockicon.svg', *@path  {
             static "resources/clockicon.svg", @path;
         }
-    get -> 'b3.svg', *@path {
+        get -> 'b3.svg', *@path {
         static "resources/b3.svg", @path;
-    }
-    }
-
-    post -> 'calendar', :$sessionToken is cookie = '' , :$date {
-        if $sessionToken {
-            request-body -> (:$date){
-                Micronomy.calendar(date => $date);
-            }
-        } else {
-            redirect "/login", :see-other;
         }
     }
-    get -> 'calendar', $sessionToken is cookie = '', {
-        if $sessionToken {
-            Micronomy.calendar(date => '');
-        } else {
-            redirect "/login", :see-other;
-}
-    }
-
 }

--- a/lib/Routes.pm6
+++ b/lib/Routes.pm6
@@ -107,7 +107,6 @@ sub routes() is export {
         }
         } 
 
-
         get -> 'styles', *@path {
             static "resources/styles", @path;
         }

--- a/lib/Routes.pm6
+++ b/lib/Routes.pm6
@@ -98,8 +98,26 @@ sub routes() is export {
         get -> 'clockicon.svg', *@path  {
             static "resources/clockicon.svg", @path;
         }
-	get -> 'b3.svg', *@path {
-	    static "resources/b3.svg", @path;
-	}
+    get -> 'b3.svg', *@path {
+        static "resources/b3.svg", @path;
     }
+    }
+
+    post -> 'calendar', :$sessionToken is cookie = '' , :$date {
+        if $sessionToken {
+            request-body -> (:$date){
+                Micronomy.calendar(date => $date);
+            }
+        } else {
+            redirect "/login", :see-other;
+        }
+    }
+    get -> 'calendar', $sessionToken is cookie = '', {
+        if $sessionToken {
+            Micronomy.calendar(date => '');
+        } else {
+            redirect "/login", :see-other;
+}
+    }
+
 }

--- a/resources/script/download.js
+++ b/resources/script/download.js
@@ -1,0 +1,11 @@
+var icsElement = document.getElementById("ics");
+if (icsElement.innerText != ""){ 
+    var a = document.createElement('a');
+    var yrinput = document.getElementById("yearinput");
+    yrinput.append(a);
+    a.setAttribute('download','Calendar.ics')
+    a.innerText = "Hello world!";
+    a.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(icsElement.innerText));
+    a.setAttribute('class', 'save-button';
+}
+

--- a/resources/templates/calendar.html.tmpl
+++ b/resources/templates/calendar.html.tmpl
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<:use 'common.html.tmpl'>
+<&head('rader')>
+    <?.error><div class='error'>Error: <.error></div></?>
+    <div class="center-container">
+      <h2>Init kalender framställning</h2>
+
+      <div class="content">
+        <div class="panel-shadow">
+          <div class="panel-title">Calendar</div>
+          <form action="/calendar" method="POST">
+            <div class="panel">
+              <div class="ics-spacer" id="yearinput">
+                <input type="number" pattern="[0-9]{4}" class="cal-box input__text nav-field" name="date" value="<.date>" >
+              </div>
+              <div>
+                <pre id=ics><.ics></pre>
+              </div>
+            </div>
+            <div class="save-button-container">
+              <input type="submit" class="save-button" value="Uppdatera" />
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <form action="/" method="POST">
+        <input type="hidden" name="date" value="<.date>" />
+        <input class="fancy-button back-button" type="submit" value="Tillbaka" />
+      </form>
+
+    <script src="/script/download.js"></Script>
+      <&foot>
+
+    </div>
+  </body>
+</html>
+


### PR DESCRIPTION
Left in a separate ranch in case you are working on something in master.

This is a baseline for ICS generation for the red days that init has. Unfortunately it also covers weekends and common red days. But unless the underlying logic for the expected function is changed there is no way to correct this since that function takes into account common red days as well as weekends.

There is no added css here perhaps that should be done to make behaviour match the rest of micronomy. 
Since the pattern is some other classes in micronomy there is some mimicking but it is not perfect.

I also have not been able to successfully test token behaviour since for some reason i get incorrect token when trying to login on the local docker. I copied behavior of other parts of the router so i think it should be working checkout the $sessionToken parts of the two calendar routes in /lib/Routes.pm6.

