### PR TITLE
Updated the download java script

### DIFF
--- a/resources/script/download.js
+++ b/resources/script/download.js
@@ -1,11 +1,12 @@
 var icsElement = document.getElementById("ics");
 if (icsElement.innerText != ""){ 
-    var a = document.createElement('a');
-    var yrinput = document.getElementById("yearinput");
-    yrinput.append(a);
-    a.setAttribute('download','Calendar.ics');
-    a.innerText = "Dowload ICS";
-    a.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(icsElement.innerText));
-    a.setAttribute('class', 'save-button');
+    let link = document.createElement('a');
+    let yrinput = document.getElementById("yearinput");
+    yrinput.append(link);
+    let data = new Blob([icsElement.innerText],{ type: 'text/calendar' });
+    link.setAttribute('download', 'Calendar.ics');
+    //link.href = 'data:text/calendar;charset=utf-8,' + encodeURIComponent(icsElement.innerText);
+    link.href = window.URL.createObjectURL(data);
+    link.textContent = 'Download ICS';
+    link.setAttribute('class','save-button');
 }
-


### PR DESCRIPTION
The script should now  works with 'all' browsers. a user reported he received a text file instead of an ics file which appeared to be connected to browser usage.

after some suggestions from kim there now is an updated script wit hsome changes that should be more according to JS standards as well.